### PR TITLE
Update Readme about normal file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Mount the uploader to your model:
 mount_base64_uploader :image, ImageUploader
 ```
 
-Now you can also upload files by passing an encoded base64 string to the attribute.
+Now you can also upload files by passing an encoded base64 string to the attribute. This also works for normal file uploads from file fields inside an HTML form, so you can safely replace `mount_uploader` with `mount_base64_uploader` to support both file input and base64 encoded input
 
 ## Upload file extension
 


### PR DESCRIPTION
It looks like `mount_base64_uploader` support both base64 encoded input and the normal file input from an HTML form. I was of the impression, I might need to do both `mount_uploader :picture` and `mount_base64_uploader :base64_picture` to do that. Updating the Readme with that information. Let me know which one is the correct way to do it and I will update the PR accordingly.