### PR TITLE
Extension from filename

### DIFF
--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -31,12 +31,13 @@ module Carrierwave
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?('(null)')
 
+        bytes = ::Base64.decode64 encoded_bytes
+
         if use_extension_from_file_name
           @file_name = file_name.split('.')[0..-2].join('.')
           @file_extension = file_name.split('.').last
         else
           @file_name = file_name
-          bytes = ::Base64.decode64 encoded_bytes
           @file_extension = get_file_extension description, bytes
         end
 

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -19,19 +19,26 @@ module Carrierwave
       #
       # @param encoded_file [String] the base64 encoded file contents
       # @param file_name [String] the file name without extention
+      # @param use_extension_from_file_name [Boolean] If true, we will not try to infer the file extension from the 
+      #                                     bytes or from the description.
       #
       # @raise [ArgumentError] If the base64 encoded string is empty
       #
       # @return [StringIO] StringIO with decoded bytes
-      def initialize(encoded_file, file_name)
+      def initialize(encoded_file, file_name, use_extension_from_file_name = false)
         description, encoded_bytes = encoded_file.split(',')
 
         raise ArgumentError unless encoded_bytes
         raise ArgumentError if encoded_bytes.eql?('(null)')
 
-        @file_name = file_name
-        bytes = ::Base64.decode64 encoded_bytes
-        @file_extension = get_file_extension description, bytes
+        if use_extension_from_file_name
+          @file_name = file_name.split('.')[0..-2].join('.')
+          @file_extension = file_name.split('.').last
+        else
+          @file_name = file_name
+          bytes = ::Base64.decode64 encoded_bytes
+          @file_extension = get_file_extension description, bytes
+        end
 
         super bytes
       end

--- a/lib/carrierwave/base64/mounting_helper.rb
+++ b/lib/carrierwave/base64/mounting_helper.rb
@@ -52,9 +52,12 @@ module Carrierwave
           return super(data) unless data.is_a?(String) &&
                                     data.strip.start_with?('data')
 
+          use_extension_from_file_name = options.fetch(:use_extension_from_file_name, false)
+
           super Carrierwave::Base64::Base64StringIO.new(
             data.strip,
-            Carrierwave::Base64::MountingHelper.file_name(self, options)
+            Carrierwave::Base64::MountingHelper.file_name(self, options),
+            use_extension_from_file_name
           )
         end
       end


### PR DESCRIPTION
Some files like `.docx` and others from that family are "glorified" zip files, If you try to upload those files base64 encoded they will end up stored with the `.zip` extension.

In this PR I've added an option to use the extension provided on the `file_name` option.