### PR TITLE
Pass block from mount_base64_uploader to mount_uploader

### DIFF
--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -17,6 +17,13 @@ module Carrierwave
       #   mount_base64_uploader :image, ImageUploader,
       #     file_name: -> (u) { u.username }
       #
+      # @example Mount the uploader with a block, overriding the store_dir
+      #   mount_base64_uploader :image, ImageUploader do
+      #     def store_dir
+      #       'images'
+      #     end
+      #   end
+      #
       # @return [Symbol] the defined writer method name
       def mount_base64_uploader(attribute, uploader_class, options = {}, &block)
         mount_uploader attribute, uploader_class, options, &block

--- a/lib/carrierwave/base64/adapter.rb
+++ b/lib/carrierwave/base64/adapter.rb
@@ -18,8 +18,8 @@ module Carrierwave
       #     file_name: -> (u) { u.username }
       #
       # @return [Symbol] the defined writer method name
-      def mount_base64_uploader(attribute, uploader_class, options = {})
-        mount_uploader attribute, uploader_class, options
+      def mount_base64_uploader(attribute, uploader_class, options = {}, &block)
+        mount_uploader attribute, uploader_class, options, &block
         options[:file_name] ||= proc { attribute }
 
         Carrierwave::Base64::MountingHelper.check_for_deprecations(options)

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -170,5 +170,24 @@ RSpec.describe Carrierwave::Base64::Adapter do
         expect { subject.update!(username: 'new-username') }.not_to raise_error
       end
     end
+
+    context 'models with a block for the uploader' do
+      subject do
+        User.mount_base64_uploader(:image, uploader) do
+          def monkey
+            'blah'
+          end
+        end
+        User.new
+      end
+
+      it 'should return an instance of a subclass of CarrierWave::Uploader::Base' do
+        expect(subject.image).to be_a(CarrierWave::Uploader::Base)
+      end
+
+      it 'should apply any custom modifications' do
+        expect(subject.image.monkey).to eq('blah')
+      end
+    end
   end
 end


### PR DESCRIPTION
We can pass a block to the `mount_uploader` in carrierwave.
So fix to pass the block from the `mount_base64_uploader` to the `mount_uploader`.

ref. https://github.com/carrierwaveuploader/carrierwave/blob/v2.1.0/lib/carrierwave/mount.rb#L134