### PR TITLE
replace mimemagic with marcel and update carrierwave dependency

### DIFF
--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'carrierwave', '>= 0.8.0'
   spec.add_dependency 'mime-types', '~> 3.0'
-  spec.add_dependency 'mimemagic', '~> 0.3.2'
+  spec.add_dependency 'marcel', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'carrierwave-mongoid'

--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'carrierwave', '>= 0.8.0'
+  spec.add_dependency 'carrierwave', '>= 2.2.1'
   spec.add_dependency 'mime-types', '~> 3.0'
   spec.add_dependency 'marcel', '~> 1.0.0'
 

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -48,7 +48,7 @@ module Carrierwave
 
       # Determine content type from input, with provided type as fallback
       def get_file_extension(description, bytes)
-        detected_type = MimeMagic.by_magic(bytes)
+        detected_type = Marcel::Magic.by_magic(bytes)
         content_type = (detected_type && detected_type.type) ||
                        description.split(';base64').first
         mime_type = MIME::Types[content_type].last


### PR DESCRIPTION
to be free from mimemagic completely, I made 2 commits.

* replace mimemagic with marcel like carrierwave.
* update requirement of carrierwave to be 2.2.1 or higher. 

CarrierWave 2.2.1 has been released today to be free from mimemagic.
it replaced mimemagic with marcel so I think we should use this version.